### PR TITLE
FEATURE: BetterReload Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,10 +18,15 @@ repositories {
         name = "papermc"
         url = uri("https://repo.papermc.io/repository/maven-public/")
     }
+    maven {
+        name = "jitpack"
+        url = uri("https://jitpack.io")
+    }
 }
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.21.6-R0.1-SNAPSHOT")
+    compileOnly("com.github.amnoah.betterreload:api:v1.0.0")
     implementation("org.bstats:bstats-bukkit:3.1.0")
 }
 

--- a/src/main/java/com/imjustdoom/villagerinabucket/VillagerInABucket.java
+++ b/src/main/java/com/imjustdoom/villagerinabucket/VillagerInABucket.java
@@ -6,6 +6,7 @@ import com.imjustdoom.villagerinabucket.event.PreVillagerPickupEvent;
 import com.imjustdoom.villagerinabucket.event.PreVillagerPlaceEvent;
 import com.imjustdoom.villagerinabucket.event.VillagerPickupEvent;
 import com.imjustdoom.villagerinabucket.event.VillagerPlaceEvent;
+import com.imjustdoom.villagerinabucket.listener.ReloadListener;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
@@ -78,6 +79,10 @@ public class VillagerInABucket extends JavaPlugin implements Listener {
             commands.registrar().register(buildCommand, List.of("viab"));
         });
         getServer().getPluginManager().registerEvents(this, this);
+
+        if (getServer().getPluginManager().getPlugin("BetterReload") != null) {
+            getServer().getPluginManager().registerEvents(new ReloadListener(), this);
+        }
 
         Metrics metrics = new Metrics(this, 25722);
         metrics.addCustomChart(new SimplePie("updated_to_new_settings", () -> String.valueOf(Config.PERMISSIONS)));

--- a/src/main/java/com/imjustdoom/villagerinabucket/listener/ReloadListener.java
+++ b/src/main/java/com/imjustdoom/villagerinabucket/listener/ReloadListener.java
@@ -1,0 +1,20 @@
+package com.imjustdoom.villagerinabucket.listener;
+
+/*
+ * We need to separate this because any usage of this will throw class not found errors if BetterReload isnt installed.
+ */
+
+import better.reload.api.ReloadEvent;
+import com.imjustdoom.villagerinabucket.Config;
+import com.imjustdoom.villagerinabucket.VillagerInABucket;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class ReloadListener implements Listener {
+
+    @EventHandler
+    public void onReloadEvent(ReloadEvent event) {
+        Config.init();
+        event.getCommandSender().sendMessage(VillagerInABucket.PREFIX + " VillagerInABucket has been reloaded!");
+    }
+}


### PR DESCRIPTION
This PR adds support for the BetterReload plugin into VillagerInABukkit to make the reloading process easier for end users.

This has been tested to be working on a 1.21.4 Paper server with other plugins. Attached is a jar for testing.
[Compiled Jar.zip](https://github.com/user-attachments/files/23588990/Compiled.Jar.zip)
