### PR TITLE
Add Folia support and ensure thread safety for file logging and config

### DIFF
--- a/src/main/java/com/imjustdoom/villagerinabucket/Config.java
+++ b/src/main/java/com/imjustdoom/villagerinabucket/Config.java
@@ -7,20 +7,20 @@ import java.util.List;
 import org.bukkit.configuration.file.FileConfiguration;
 
 public class Config {
-    public static boolean PERMISSIONS = true;
-    public static boolean VILLAGER = true;
-    public static boolean ZOMBIE_VILLAGER = true;
-    public static boolean WANDERING_TRADER = true;
-    public static boolean DISABLE_PLACING_OF_DISABLED = false;
-    public static boolean HARM_REPUTATION = false;
+    public static volatile boolean PERMISSIONS = true;
+    public static volatile boolean VILLAGER = true;
+    public static volatile boolean ZOMBIE_VILLAGER = true;
+    public static volatile boolean WANDERING_TRADER = true;
+    public static volatile boolean DISABLE_PLACING_OF_DISABLED = false;
+    public static volatile boolean HARM_REPUTATION = false;
 
-    public static boolean RESOURCE_PACK = true;
-    public static String RESOURCE_PACK_URL = "https://cdn.modrinth.com/data/9tf9GGch/versions/ZBgqIN0Y/VillagerInABukkitPack.zip";
-    public static String RESOURCE_PACK_HASH = "f2d4dd5bf8ee221234b738236099b2592c58b8e8";
-    public static String RESOURCE_PACK_ID = "68a4b411-e409-4d89-b563-66049ba4914b";
+    public static volatile boolean RESOURCE_PACK = true;
+    public static volatile String RESOURCE_PACK_URL = "https://cdn.modrinth.com/data/9tf9GGch/versions/ZBgqIN0Y/VillagerInABukkitPack.zip";
+    public static volatile String RESOURCE_PACK_HASH = "f2d4dd5bf8ee221234b738236099b2592c58b8e8";
+    public static volatile String RESOURCE_PACK_ID = "68a4b411-e409-4d89-b563-66049ba4914b";
 
-    public static boolean CONSOLE_LOGGING = false;
-    public static boolean FILE_LOGGING = false;
+    public static volatile boolean CONSOLE_LOGGING = false;
+    public static volatile boolean FILE_LOGGING = false;
 
     public static void init() {
         VillagerInABucket.get().saveDefaultConfig();
@@ -57,16 +57,28 @@ public class Config {
         CONSOLE_LOGGING = fileConfiguration.getBoolean("console-logging", CONSOLE_LOGGING);
         FILE_LOGGING = fileConfiguration.getBoolean("file-logging", FILE_LOGGING);
 
-        if (FILE_LOGGING) {
-            try {
-                if (VillagerInABucket.get().logFileWriter != null) {
-                    VillagerInABucket.get().logFileWriter.close();
+        synchronized (VillagerInABucket.get().logLock) {
+            if (FILE_LOGGING) {
+                try {
+                    if (VillagerInABucket.get().logFileWriter != null) {
+                        VillagerInABucket.get().logFileWriter.close();
+                        VillagerInABucket.get().logFileWriter = null;
+                    }
+                    File logFile = new File(VillagerInABucket.get().getDataFolder(), "villager-actions.log");
+                    VillagerInABucket.get().logFileWriter = new FileWriter(logFile, true);
+                } catch (IOException e) {
+                    FILE_LOGGING = false;
+                    VillagerInABucket.get().getLogger().severe("Unable to create a log writer for villager actions: " + e.getMessage());
                 }
-                File logFile = new File(VillagerInABucket.get().getDataFolder(), "villager-actions.log");
-                VillagerInABucket.get().logFileWriter = new FileWriter(logFile, true);
-            } catch (IOException e) {
-                FILE_LOGGING = false;
-                VillagerInABucket.get().getLogger().severe("Unable to create a log writer for villager actions: " + e.getMessage());
+            } else {
+                if (VillagerInABucket.get().logFileWriter != null) {
+                    try {
+                        VillagerInABucket.get().logFileWriter.close();
+                        VillagerInABucket.get().logFileWriter = null;
+                    } catch (IOException e) {
+                        VillagerInABucket.get().getLogger().severe("Unable to close log writer: " + e.getMessage());
+                    }
+                }
             }
         }
     }

--- a/src/main/java/com/imjustdoom/villagerinabucket/VillagerInABucket.java
+++ b/src/main/java/com/imjustdoom/villagerinabucket/VillagerInABucket.java
@@ -56,6 +56,7 @@ public class VillagerInABucket extends JavaPlugin implements Listener {
 
     public NamespacedKey key = new NamespacedKey(this, "villager_data");
     public FileWriter logFileWriter;
+    public final Object logLock = new Object();
 
     public VillagerInABucket() {
         INSTANCE = this;
@@ -92,11 +93,14 @@ public class VillagerInABucket extends JavaPlugin implements Listener {
 
     @Override
     public void onDisable() {
-        if (this.logFileWriter != null) {
-            try {
-                this.logFileWriter.close();
-            } catch (IOException e) {
-                getLogger().severe("Unable to close villager action file logger");
+        synchronized (logLock) {
+            if (this.logFileWriter != null) {
+                try {
+                    this.logFileWriter.close();
+                    this.logFileWriter = null;
+                } catch (IOException e) {
+                    getLogger().severe("Unable to close villager action file logger");
+                }
             }
         }
     }
@@ -364,10 +368,15 @@ public class VillagerInABucket extends JavaPlugin implements Listener {
             getLogger().info(message);
         }
         if (Config.FILE_LOGGING) {
-            try {
-                this.logFileWriter.write("[" + LocalDateTime.now().format(TIMESTAMP_FORMAT) + "] " + message + System.lineSeparator());
-            } catch (IOException e) {
-                getLogger().severe("Unable to write to log file: " + e.getMessage());
+            synchronized (logLock) {
+                if (this.logFileWriter != null) {
+                    try {
+                        this.logFileWriter.write("[" + LocalDateTime.now().format(TIMESTAMP_FORMAT) + "] " + message + System.lineSeparator());
+                        this.logFileWriter.flush();
+                    } catch (IOException e) {
+                        getLogger().severe("Unable to write to log file: " + e.getMessage());
+                    }
+                }
             }
         }
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,6 +5,7 @@ api-version: '26.1.2'
 description: Plugin version of Villager In A Bucket
 author: JustDoom
 website: https://imjustdoom.com
+folia-supported: true
 
 permissions:
   villagerinabucket.commands:


### PR DESCRIPTION
- Mark config fields as volatile for concurrent access.
- Synchronize file logger operations on a dedicated lock object (logLock) to prevent concurrent write and close issues.
- Properly close and nullify the logFileWriter on config reload or plugin disable.
- Set folia-supported to true in plugin.yml.